### PR TITLE
Screen Rotation

### DIFF
--- a/OctoPiPanel.cfg
+++ b/OctoPiPanel.cfg
@@ -7,3 +7,4 @@ backlightofftime = 30000
 
 window_width = 320
 window_height = 240
+rotation = NONE

--- a/OctoPiPanel.py
+++ b/OctoPiPanel.py
@@ -107,6 +107,7 @@ class OctoPiPanel():
 				os.putenv('SDL_FBDEV'      , '/dev/fb1')
 				os.putenv('SDL_MOUSEDRV'   , 'TSLIB')
 				os.putenv('SDL_MOUSEDEV'   , '/dev/input/touchscreen')
+				os.putenv('SDL_VIDEO_FBCON_ROTATION', self.rotation)
 
         # init pygame and set up screen
         pygame.init()

--- a/OctoPiPanel.py
+++ b/OctoPiPanel.py
@@ -32,6 +32,7 @@ class OctoPiPanel():
     apikey = cfg.get('settings', 'apikey')
     updatetime = cfg.getint('settings', 'updatetime')
     backlightofftime = cfg.getint('settings', 'backlightofftime')
+    rotation = cfg.get('settings', 'rotation')
 
     if cfg.has_option('settings', 'window_width'):
         win_width = cfg.getint('settings', 'window_width')
@@ -42,6 +43,11 @@ class OctoPiPanel():
         win_height = cfg.getint('settings', 'window_height')
     else:
         win_height = 240
+        
+    if cfg.has_option('settings', 'rotation'):
+    	rotation = cfg.get('settings', 'rotation')
+    else:
+    	rotation = 'NONE'
 
     addkey = '?apikey={0}'.format(apikey)
     apiurl_printhead = '{0}/api/printer/printhead'.format(api_baseurl)


### PR DESCRIPTION
Preliminary changes for screen rotation with Raspberry Pi and fbcon.  Adds a rotation setting to cfg file for what rotation to use based on availlable "SDL_VIDEO_FBCON_ROTATION" options. You can use any of the following:
- "NONE" - Not rotating, but still using shadow.
- "CW" - Rotating screen clockwise.
- "UD" - Rotating screen upside down.
- "CCW" - Rotating screen counter clockwise.

Any suggestions to make this more usable are welcome.
