### PR TITLE
Bug Fix- OctoPiPanel Crashes if there is no Heated Bed

### DIFF
--- a/OctoPiPanel.py
+++ b/OctoPiPanel.py
@@ -278,8 +278,10 @@ class OctoPiPanel():
         
                 # Set status flags
                 tempKey = 'temps' if 'temps' in state else 'temperature'
-                self.HotEndTemp = state[tempKey]['tool0']['actual']
-                self.HotEndTempTarget = state[tempKey]['tool0']['target']
+
+		if 'tool0' in state[tempKey]:
+	                self.HotEndTemp = state[tempKey]['tool0']['actual']
+        	        self.HotEndTempTarget = state[tempKey]['tool0']['target']
 
 		if 'bed' in state[tempKey]:
 			self.BedTemp = state[tempKey]['bed']['actual']

--- a/OctoPiPanel.py
+++ b/OctoPiPanel.py
@@ -279,9 +279,14 @@ class OctoPiPanel():
                 # Set status flags
                 tempKey = 'temps' if 'temps' in state else 'temperature'
                 self.HotEndTemp = state[tempKey]['tool0']['actual']
-                self.BedTemp = state[tempKey]['bed']['actual']
                 self.HotEndTempTarget = state[tempKey]['tool0']['target']
-                self.BedTempTarget = state[tempKey]['bed']['target']
+
+		if 'bed' in state[tempKey]:
+			self.BedTemp = state[tempKey]['bed']['actual']
+			self.BedTempTarget = state[tempKey]['bed']['target']
+		else:
+			self.BedTemp = -1;
+			self.BedTempTarget = -1;
 
                 if self.HotEndTempTarget == None:
                     self.HotEndTempTarget = 0.0


### PR DESCRIPTION
I have an M3D Micro and was receiving the following error:

> Traceback (most recent call last):
>   File "./OctoPiPanel.py", line 586, in <module>
>     opp.Start()
>   File "./OctoPiPanel.py", line 174, in Start
>     self.get_state()
>   File "./OctoPiPanel.py", line 282, in get_state
>     self.BedTemp = state[tempKey]['bed']['actual']
> KeyError: 'bed'

This pull request will set the bed temp to -1 if it doesn't exist and prevent this crash.

If it's set to -1 the bed buttons and information can be hidden from the UI (Not done yet)

I will remove the bed info/ buttons as part of another pull request when i have time- but at least it runs for now :-)
